### PR TITLE
feat: add cross-chain output

### DIFF
--- a/protocol/bc/bc.pb.go
+++ b/protocol/bc/bc.pb.go
@@ -22,6 +22,7 @@ It has these top-level messages:
 	Mux
 	Coinbase
 	Output
+	CrossChainOutput
 	Retirement
 	Issuance
 	Spend
@@ -514,6 +515,38 @@ func (m *Output) GetControlProgram() *Program {
 }
 
 func (m *Output) GetOrdinal() uint64 {
+	if m != nil {
+		return m.Ordinal
+	}
+	return 0
+}
+
+type CrossChainOutput struct {
+	Source         *ValueSource `protobuf:"bytes,1,opt,name=source" json:"source,omitempty"`
+	ControlProgram *Program     `protobuf:"bytes,2,opt,name=control_program,json=controlProgram" json:"control_program,omitempty"`
+	Ordinal        uint64       `protobuf:"varint,3,opt,name=ordinal" json:"ordinal,omitempty"`
+}
+
+func (m *CrossChainOutput) Reset()                    { *m = CrossChainOutput{} }
+func (m *CrossChainOutput) String() string            { return proto.CompactTextString(m) }
+func (*CrossChainOutput) ProtoMessage()               {}
+func (*CrossChainOutput) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{13} }
+
+func (m *CrossChainOutput) GetSource() *ValueSource {
+	if m != nil {
+		return m.Source
+	}
+	return nil
+}
+
+func (m *CrossChainOutput) GetControlProgram() *Program {
+	if m != nil {
+		return m.ControlProgram
+	}
+	return nil
+}
+
+func (m *CrossChainOutput) GetOrdinal() uint64 {
 	if m != nil {
 		return m.Ordinal
 	}

--- a/protocol/bc/bc.proto
+++ b/protocol/bc/bc.proto
@@ -94,6 +94,12 @@ message Output {
   uint64      ordinal         = 3;
 }
 
+message CrossChainOutput {
+  ValueSource source          = 1;
+  Program     control_program = 2;
+  uint64      ordinal         = 3;
+}
+
 message Retirement {
   ValueSource source   = 1;
   uint64      ordinal  = 2;

--- a/protocol/bc/crosschain_output.go
+++ b/protocol/bc/crosschain_output.go
@@ -1,0 +1,18 @@
+package bc
+
+import "io"
+
+func (CrossChainOutput) typ() string { return "crosschainoutput1" }
+func (o *CrossChainOutput) writeForHash(w io.Writer) {
+	mustWriteForHash(w, o.Source)
+	mustWriteForHash(w, o.ControlProgram)
+}
+
+// NewClaimOutput creates a new CrossChainOutput for a claim tx.
+func NewCrossChainOutput(source *ValueSource, controlProgram *Program, ordinal uint64) *CrossChainOutput {
+	return &CrossChainOutput{
+		Source:         source,
+		ControlProgram: controlProgram,
+		Ordinal:        ordinal,
+	}
+}

--- a/protocol/bc/types/map.go
+++ b/protocol/bc/types/map.go
@@ -156,8 +156,13 @@ func mapTx(tx *TxData) (headerID bc.Hash, hdr *bc.TxHeader, entryMap map[bc.Hash
 		} else {
 			// non-retirement
 			prog := &bc.Program{out.VMVersion, out.ControlProgram}
-			o := bc.NewOutput(src, prog, uint64(i))
-			resultID = addEntry(o)
+			if out.IsCrossChain {
+				o := bc.NewCrossChainOutput(src, prog, uint64(i))
+				resultID = addEntry(o)
+			} else {
+				o := bc.NewOutput(src, prog, uint64(i))
+				resultID = addEntry(o)
+			}
 		}
 
 		dest := &bc.ValueDestination{

--- a/protocol/bc/types/txoutput.go
+++ b/protocol/bc/types/txoutput.go
@@ -14,6 +14,7 @@ type TxOutput struct {
 	OutputCommitment
 	// Unconsumed suffixes of the commitment and witness extensible strings.
 	CommitmentSuffix []byte
+	IsCrossChain     bool
 }
 
 // NewTxOutput create a new output struct

--- a/protocol/bc/types/txoutput.go
+++ b/protocol/bc/types/txoutput.go
@@ -32,6 +32,13 @@ func NewTxOutput(assetID bc.AssetID, amount uint64, controlProgram []byte) *TxOu
 	}
 }
 
+// NewCrossChainTxOutput create a new output struct for a cross-chain tx
+func NewCrossChainTxOutput(assetID bc.AssetID, amount uint64, controlProgram []byte) *TxOutput {
+	output := NewTxOutput(assetID, amount, controlProgram)
+	output.IsCrossChain = true
+	return output
+}
+
 func (to *TxOutput) readFrom(r *blockchain.Reader) (err error) {
 	if to.AssetVersion, err = blockchain.ReadVarint63(r); err != nil {
 		return errors.Wrap(err, "reading asset version")

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -481,13 +481,25 @@ func checkStandardTx(tx *bc.Tx, blockHeight uint64) error {
 			return errors.Wrapf(bc.ErrMissingEntry, "id %x", id.Bytes())
 		}
 
-		// TODO: fix here
-		output, ok := e.(*bc.Output)
-		if !ok || *output.Source.Value.AssetId != *consensus.BTMAssetID {
+		var prog []byte
+		switch e := e.(type) {
+		case *bc.Output:
+			if *e.Source.Value.AssetId != *consensus.BTMAssetID {
+				continue
+			}
+			prog = e.ControlProgram.Code
+
+		case *bc.CrossChainOutput:
+			if *e.Source.Value.AssetId != *consensus.BTMAssetID {
+				continue
+			}
+			prog = e.ControlProgram.Code
+
+		default:
 			continue
 		}
 
-		if !segwit.IsP2WScript(output.ControlProgram.Code) {
+		if !segwit.IsP2WScript(prog) {
 			return ErrNotStandardTx
 		}
 	}

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -481,6 +481,7 @@ func checkStandardTx(tx *bc.Tx, blockHeight uint64) error {
 			return errors.Wrapf(bc.ErrMissingEntry, "id %x", id.Bytes())
 		}
 
+		// TODO: fix here
 		output, ok := e.(*bc.Output)
 		if !ok || *output.Source.Value.AssetId != *consensus.BTMAssetID {
 			continue

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -551,7 +551,7 @@ func TestTxValidation(t *testing.T) {
 			err: vm.ErrRunLimitExceeded,
 		},
 		{
-			desc: "check cross-chain output gas",
+			desc: "check cross-chain output gas bypassing",
 			f: func() {
 				// del gas spend input
 				spendID := mux.Sources[len(mux.Sources)-1].Ref

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -560,7 +560,7 @@ func TestTxValidation(t *testing.T) {
 				tx.GasInputIDs = nil
 				vs.gasStatus.GasLeft = 0
 
-				// forcely convert output as cross-chain output
+				// forcely convert output to cross-chain output
 				outputID := tx.ResultIds[0]
 				output := tx.Entries[*outputID].(*bc.Output)
 				crossChainOutput := bc.NewCrossChainOutput(output.Source, output.ControlProgram, output.Ordinal)


### PR DESCRIPTION
+ 加了 bc.CrossChainOutput
+ 加了 probuf 相关
+ 加了 bc <-> types 层mapping
+ validation 直接给够 gas
+ 加了含 CrossChainOutput 交易绕过 gas 的测试
+ types 层的 read write尝试写时发现很多 test 数据（raw_tx, raw_block）要改，这个pr 暂时不包含。