### PR TITLE
keep last irreversible block on the main chain

### DIFF
--- a/netsync/chainmgr/block_keeper.go
+++ b/netsync/chainmgr/block_keeper.go
@@ -190,7 +190,7 @@ func (bk *blockKeeper) syncWorker() {
 				continue
 			}
 
-			if err := bk.peers.BroadcastNewStatus(bk.chain.BestBlockHeader(), bk.chain.BestIrreversibleHeader()); err != nil {
+			if err := bk.peers.BroadcastNewStatus(bk.chain.BestBlockHeader(), bk.chain.LastIrreversibleHeader()); err != nil {
 				log.WithFields(log.Fields{"module": logModule, "err": err}).Error("fail on syncWorker broadcast new status")
 			}
 		case <-bk.quit:

--- a/netsync/chainmgr/handle.go
+++ b/netsync/chainmgr/handle.go
@@ -25,7 +25,7 @@ const (
 // Chain is the interface for Bytom core
 type Chain interface {
 	BestBlockHeader() *types.BlockHeader
-	BestIrreversibleHeader() *types.BlockHeader
+	LastIrreversibleHeader() *types.BlockHeader
 	BestBlockHeight() uint64
 	GetBlockByHash(*bc.Hash) (*types.Block, error)
 	GetBlockByHeight(uint64) (*types.Block, error)
@@ -351,7 +351,7 @@ func (m *Manager) SendStatus(peer peers.BasePeer) error {
 		return errors.New("invalid peer")
 	}
 
-	if err := p.SendStatus(m.chain.BestBlockHeader(), m.chain.BestIrreversibleHeader()); err != nil {
+	if err := p.SendStatus(m.chain.BestBlockHeader(), m.chain.LastIrreversibleHeader()); err != nil {
 		m.peers.RemovePeer(p.ID())
 		return err
 	}

--- a/protocol/bbft.go
+++ b/protocol/bbft.go
@@ -221,6 +221,9 @@ func (c *Chain) SignBlock(block *types.Block) ([]byte, error) {
 
 func (c *Chain) updateBlockSignature(blockHeader *types.BlockHeader, nodeOrder uint64, signature []byte) error {
 	blockHeader.Set(nodeOrder, signature)
+	if err := c.store.SaveBlockHeader(blockHeader); err != nil {
+		return err
+	}
 
 	if !c.isIrreversible(blockHeader) || blockHeader.Height <= c.lastIrrBlockHeader.Height {
 		return nil

--- a/protocol/bbft.go
+++ b/protocol/bbft.go
@@ -98,7 +98,7 @@ func (c *Chain) ProcessBlockSignature(signature, xPub []byte, blockHash *bc.Hash
 
 // validateSign verify the signatures of block, and return the number of correct signature
 // if some signature is invalid, they will be reset to nil
-// if the block has not the signature of blocker, it will return error
+// if the block does not have the signature of blocker, it will return error
 func (c *Chain) validateSign(block *types.Block) error {
 	consensusNodeMap, err := c.getConsensusNodes(&block.PreviousBlockHash)
 	if err != nil {
@@ -221,15 +221,26 @@ func (c *Chain) SignBlock(block *types.Block) ([]byte, error) {
 
 func (c *Chain) updateBlockSignature(blockHeader *types.BlockHeader, nodeOrder uint64, signature []byte) error {
 	blockHeader.Set(nodeOrder, signature)
-	if err := c.store.SaveBlockHeader(blockHeader); err != nil {
-		return err
+
+	if !c.isIrreversible(blockHeader) || blockHeader.Height <= c.lastIrrBlockHeader.Height {
+		return nil
 	}
 
-	if c.isIrreversible(blockHeader) && blockHeader.Height > c.bestIrrBlockHeader.Height {
+	if c.InMainChain(blockHeader.Hash()) {
 		if err := c.store.SaveChainStatus(c.bestBlockHeader, blockHeader, []*types.BlockHeader{}, state.NewUtxoViewpoint(), []*state.ConsensusResult{}); err != nil {
 			return err
 		}
-		c.bestIrrBlockHeader = blockHeader
+
+		c.lastIrrBlockHeader = blockHeader
+	} else {
+		// block is on a forked chain
+		log.WithFields(log.Fields{"module": logModule}).Info("majority votes received on forked chain")
+		tail, err := c.traceLongestChainTail(blockHeader)
+		if err != nil {
+			return err
+		}
+
+		return c.reorganizeChain(tail)
 	}
 	return nil
 }

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -110,7 +110,7 @@ func (c *Chain) connectBlock(block *types.Block) (err error) {
 		return err
 	}
 
-	irrBlockHeader := c.bestIrrBlockHeader
+	irrBlockHeader := c.lastIrrBlockHeader
 	if c.isIrreversible(&block.BlockHeader) && block.Height > irrBlockHeader.Height {
 		irrBlockHeader = &block.BlockHeader
 	}
@@ -167,7 +167,7 @@ func (c *Chain) reorganizeChain(blockHeader *types.BlockHeader) error {
 		log.WithFields(log.Fields{"module": logModule, "height": blockHeader.Height, "hash": blockHash.String()}).Debug("detach from mainchain")
 	}
 
-	irrBlockHeader := c.bestIrrBlockHeader
+	irrBlockHeader := c.lastIrrBlockHeader
 	for _, attachBlockHeader := range attachBlockHeaders {
 		attachHash := attachBlockHeader.Hash()
 		b, err := c.store.GetBlock(&attachHash)
@@ -205,7 +205,9 @@ func (c *Chain) reorganizeChain(blockHeader *types.BlockHeader) error {
 		log.WithFields(log.Fields{"module": logModule, "height": blockHeader.Height, "hash": blockHash.String()}).Debug("attach from mainchain")
 	}
 
-	if len(detachBlockHeaders) > 0 && detachBlockHeaders[len(detachBlockHeaders)-1].Height <= c.bestIrrBlockHeader.Height && irrBlockHeader.Height <= c.bestIrrBlockHeader.Height {
+	if len(detachBlockHeaders) > 0 &&
+		detachBlockHeaders[len(detachBlockHeaders)-1].Height <= c.lastIrrBlockHeader.Height &&
+		irrBlockHeader.Height <= c.lastIrrBlockHeader.Height {
 		return errors.New("rollback block below the height of irreversible block")
 	}
 	consensusResults = append(consensusResults, consensusResult.Fork())

--- a/test/mock/chain.go
+++ b/test/mock/chain.go
@@ -37,7 +37,7 @@ func (c *Chain) BestBlockHeight() uint64 {
 	return c.bestBlockHeader.Height
 }
 
-func (c *Chain) BestIrreversibleHeader() *types.BlockHeader {
+func (c *Chain) LastIrreversibleHeader() *types.BlockHeader {
 	return c.bestBlockHeader
 }
 


### PR DESCRIPTION
Only update the LIB pointer when newly irreversible block is on the main
chain. Emit warning otherwise.