### PR TITLE
refactor(federation db): change asset definition encoding

### DIFF
--- a/federation/database/orm/asset.go
+++ b/federation/database/orm/asset.go
@@ -5,11 +5,11 @@ import (
 )
 
 type Asset struct {
-	ID                uint64          `gorm:"primary_key;foreignkey:ID" json:"-"`
-	AssetID           string          `json:"asset_id"`
-	IssuanceProgram   string          `json:"-"`
-	VMVersion         uint64          `json:"-"`
-	RawDefinitionByte string          `json:"-"`
-	CreatedAt         types.Timestamp `json:"-"`
-	UpdatedAt         types.Timestamp `json:"-"`
+	ID              uint64          `gorm:"primary_key;foreignkey:ID" json:"-"`
+	AssetID         string          `json:"asset_id"`
+	IssuanceProgram string          `json:"-"`
+	VMVersion       uint64          `json:"-"`
+	Definition      string          `json:"-"`
+	CreatedAt       types.Timestamp `json:"-"`
+	UpdatedAt       types.Timestamp `json:"-"`
 }

--- a/federation/synchron/mainchain_keeper.go
+++ b/federation/synchron/mainchain_keeper.go
@@ -314,10 +314,10 @@ func (m *mainchainKeeper) processIssuing(txs []*types.Tx) error {
 				}
 
 				m.assetStore.Add(&orm.Asset{
-					AssetID:           assetID.String(),
-					IssuanceProgram:   hex.EncodeToString(inp.IssuanceProgram),
-					VMVersion:         inp.VMVersion,
-					RawDefinitionByte: hex.EncodeToString(inp.AssetDefinition),
+					AssetID:         assetID.String(),
+					IssuanceProgram: hex.EncodeToString(inp.IssuanceProgram),
+					VMVersion:       inp.VMVersion,
+					Definition:      string(inp.AssetDefinition),
 				})
 			}
 		}


### PR DESCRIPTION
This PR is intended to:
+ follow the same encoding rule for asset definition as blockcenter
+ save hex.DecodeString() overhead
+ increase readability for db data