### PR TITLE
Fix BlockSignatureMsg unbroadcast problem

### DIFF
--- a/netsync/consensusmgr/handle.go
+++ b/netsync/consensusmgr/handle.go
@@ -67,7 +67,7 @@ func (m *Manager) processMsg(peerID string, msgType byte, msg ConsensusMessage) 
 		return
 	}
 
-	logrus.WithFields(logrus.Fields{"module": logModule, "peer": peerID, "type": reflect.TypeOf(msg), "message": msg.String()}).Info("receive message from peer")
+	logrus.WithFields(logrus.Fields{"module": logModule, "peer": peer.Addr(), "type": reflect.TypeOf(msg), "message": msg.String()}).Info("receive message from peer")
 
 	switch msg := msg.(type) {
 	case *BlockProposeMsg:

--- a/protocol/bbft.go
+++ b/protocol/bbft.go
@@ -162,17 +162,17 @@ func (c *Chain) validateSign(block *types.Block) error {
 // ProcessBlockSignature process the received block signature messages
 // return whether a block become irreversible, if so, the chain module must update status
 func (c *Chain) ProcessBlockSignature(signature, xPub []byte, blockHash *bc.Hash) error {
-	var xPubKey chainkd.XPub
-	copy(xPub[:], xPub[:])
-	if !xPubKey.Verify(blockHash.Bytes(), signature) {
-		return errInvalidSignature
-	}
-
 	xpubStr := hex.EncodeToString(xPub[:])
 	blockHeader, _ := c.store.GetBlockHeader(blockHash)
 
 	// save the signature if the block is not exist
 	if blockHeader == nil {
+		var xPubKey chainkd.XPub
+		copy(xPub[:], xPub[:])
+		if !xPubKey.Verify(blockHash.Bytes(), signature) {
+			return errInvalidSignature
+		}
+
 		cacheKey := signCacheKey(blockHash.String(), xpubStr)
 		c.signatureCache.Add(cacheKey, signature)
 		return nil


### PR DESCRIPTION
1. 解决签名在提议区块前被接收到,导致签名不会被广播的问题.
2. 签名未经验证加入缓存池可以被普通节点恶意攻击.