### PR TITLE
Fix signature msg broadcast exceptions

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -29,6 +29,7 @@ type NewProposedBlockEvent struct{ Block types.Block }
 
 type BlockSignatureEvent struct {
 	BlockHash bc.Hash
+	Height    uint64
 	Signature []byte
 	XPub      []byte
 }

--- a/netsync/consensusmgr/handle.go
+++ b/netsync/consensusmgr/handle.go
@@ -162,16 +162,10 @@ func (m *Manager) blockSignatureMsgBroadcastLoop() {
 				continue
 			}
 
-			blockHeader, err := m.chain.GetHeaderByHash(&ev.BlockHash)
-			if err != nil {
-				logrus.WithFields(logrus.Fields{"module": logModule, "err": err}).Error("failed on get header by hash from chain.")
-				return
-			}
-
-			blockSignatureMsg := NewBroadcastMsg(NewBlockSignatureMsg(ev.BlockHash, blockHeader.Height, ev.Signature, ev.XPub), consensusChannel)
+			blockSignatureMsg := NewBroadcastMsg(NewBlockSignatureMsg(ev.BlockHash, ev.Height, ev.Signature, ev.XPub), consensusChannel)
 			if err := m.peers.BroadcastMsg(blockSignatureMsg); err != nil {
-				logrus.WithFields(logrus.Fields{"module": logModule, "err": err}).Error("failed on broadcast BlockSignBroadcastMsg.")
-				return
+				logrus.WithFields(logrus.Fields{"module": logModule, "err": err}).Warn("failed on broadcast BlockSignBroadcastMsg.")
+				continue
 			}
 
 		case <-m.quit:

--- a/protocol/bbft.go
+++ b/protocol/bbft.go
@@ -133,7 +133,7 @@ func (c *Chain) validateSign(block *types.Block) error {
 			cachekey := signCacheKey(blockHash.String(), pubKey)
 			if signature, ok := c.signatureCache.Get(cachekey); ok {
 				block.Set(node.Order, signature.([]byte))
-				c.eventDispatcher.Post(event.BlockSignatureEvent{BlockHash: blockHash, Signature: signature.([]byte), XPub: node.XPub[:]})
+				c.eventDispatcher.Post(event.BlockSignatureEvent{BlockHash: blockHash, Height: block.Height, Signature: signature.([]byte), XPub: node.XPub[:]})
 				c.signatureCache.Remove(cachekey)
 			} else {
 				continue
@@ -196,7 +196,7 @@ func (c *Chain) ProcessBlockSignature(signature, xPub []byte, blockHash *bc.Hash
 	if err := c.updateBlockSignature(blockHeader, consensusNode.Order, signature); err != nil {
 		return err
 	}
-	return c.eventDispatcher.Post(event.BlockSignatureEvent{BlockHash: *blockHash, Signature: signature, XPub: xPub})
+	return c.eventDispatcher.Post(event.BlockSignatureEvent{BlockHash: *blockHash, Height: blockHeader.Height, Signature: signature, XPub: xPub})
 }
 
 // SignBlock signing the block if current node is consensus node

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -291,7 +291,7 @@ func (c *Chain) saveBlock(block *types.Block) error {
 
 	if len(signature) != 0 {
 		xPub := config.CommonConfig.PrivateKey().XPub()
-		if err := c.eventDispatcher.Post(event.BlockSignatureEvent{BlockHash: block.Hash(), Signature: signature, XPub: xPub[:]}); err != nil {
+		if err := c.eventDispatcher.Post(event.BlockSignatureEvent{BlockHash: block.Hash(), Height: block.Height, Signature: signature, XPub: xPub[:]}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
解决由于GetHeaderByHash返回错误导致blockSignatureMsgBroadcastLoop退出的问题.
当在签名缓存中获取签名并广播时会因区块未保存从而导致GetHeaderByHash返回错误.