### PR TITLE
fix netParams for fedd

### DIFF
--- a/docs/federation/README-en.md
+++ b/docs/federation/README-en.md
@@ -24,6 +24,7 @@ A `fed_cfg.json` would look like this:
         },
         "log_mode" : true
     },
+    "network" : "testnet",
     "federation_prog" : "0020305dc12c0dbec0c1dc1f30e835034c1f19094c06afb0eb953a6d1af42222a721",
     "mainchain" : {
         "name" : "btm",

--- a/toolbar/federation/config/config.go
+++ b/toolbar/federation/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	API            API                `json:"api"`
 	MySQLConfig    common.MySQLConfig `json:"mysql"`
 	FederationProg vaporJson.HexBytes `json:"federation_prog"`
+	Network        string             `json:"network"`
 	Mainchain      Chain              `json:"mainchain"`
 	Sidechain      Chain              `json:"sidechain"`
 }

--- a/toolbar/federation/synchron/mainchain_keeper.go
+++ b/toolbar/federation/synchron/mainchain_keeper.go
@@ -31,6 +31,7 @@ type mainchainKeeper struct {
 	assetStore     *database.AssetStore
 	chainID        uint64
 	federationProg []byte
+	vaporNetParams consensus.Params
 }
 
 func NewMainchainKeeper(db *gorm.DB, assetStore *database.AssetStore, cfg *config.Config) *mainchainKeeper {
@@ -46,6 +47,7 @@ func NewMainchainKeeper(db *gorm.DB, assetStore *database.AssetStore, cfg *confi
 		assetStore:     assetStore,
 		federationProg: cfg.FederationProg,
 		chainID:        chain.ID,
+		vaporNetParams: consensus.NetParams[cfg.Network],
 	}
 }
 
@@ -68,8 +70,8 @@ func (m *mainchainKeeper) Run() {
 
 func (m *mainchainKeeper) createCrossChainReqs(db *gorm.DB, crossTransactionID uint64, tx *types.Tx, statusFail bool) error {
 	prog := tx.Inputs[0].ControlProgram()
-	fromAddress := common.ProgToAddress(prog, consensus.BytomMainNetParams(&consensus.ActiveNetParams))
-	toAddress := common.ProgToAddress(prog, &consensus.MainNetParams)
+	fromAddress := common.ProgToAddress(prog, consensus.BytomMainNetParams(&m.vaporNetParams))
+	toAddress := common.ProgToAddress(prog, &m.vaporNetParams)
 	for i, rawOutput := range tx.Outputs {
 		if !bytes.Equal(rawOutput.OutputCommitment.ControlProgram, m.federationProg) {
 			continue


### PR DESCRIPTION
federick 监听 不是读的 config.toml  所以 ActiveNetParams 这种方法没有用，默认会是 mainnet
现在改成正确读  fedd 专用的 config