### PR TITLE
fix fast sync skeleton limit error when chain fork

### DIFF
--- a/netsync/chainmgr/fast_sync.go
+++ b/netsync/chainmgr/fast_sync.go
@@ -93,7 +93,7 @@ func (fs *fastSync) createFetchBlocksTasks(stopBlock *types.Block) ([]*fetchBloc
 		return nil, errNoMainSkeleton
 	}
 
-	if len(mainSkeleton) < minSizeOfSyncSkeleton || len(mainSkeleton) > maxSizeOfSyncSkeleton {
+	if len(mainSkeleton) < minSizeOfSyncSkeleton {
 		fs.peers.ProcessIllegal(fs.mainSyncPeer.ID(), security.LevelMsgIllegal, errSkeletonSize.Error())
 		return nil, errSkeletonSize
 	}
@@ -118,7 +118,7 @@ func (fs *fastSync) createFetchBlocksTasks(stopBlock *types.Block) ([]*fetchBloc
 
 	blockFetchTasks := make([]*fetchBlocksWork, 0)
 	// create download task
-	for i := 0; i < len(mainSkeleton)-1; i++ {
+	for i := 0; i < len(mainSkeleton)-1 && i < maxSizeOfSyncSkeleton-1; i++ {
 		blockFetchTasks = append(blockFetchTasks, &fetchBlocksWork{startHeader: mainSkeleton[i], stopHeader: mainSkeleton[i+1]})
 	}
 

--- a/netsync/chainmgr/fast_sync_test.go
+++ b/netsync/chainmgr/fast_sync_test.go
@@ -99,7 +99,9 @@ func TestFastBlockSync(t *testing.T) {
 	}()
 
 	baseChain := mockBlocks(nil, 300)
-
+	chainX := []*types.Block{}
+	chainX = append(chainX, baseChain[:30]...)
+	chainX = append(chainX, mockBlocks(baseChain[30], 500)...)
 	cases := []struct {
 		syncTimeout time.Duration
 		aBlocks     []*types.Block
@@ -148,6 +150,13 @@ func TestFastBlockSync(t *testing.T) {
 			bBlocks:     baseChain[:301],
 			want:        baseChain[:50],
 			err:         errSkeletonSize,
+		},
+		{
+			syncTimeout: 30 * time.Second,
+			aBlocks:     chainX[:50],
+			bBlocks:     baseChain[:301],
+			want:        baseChain[:128],
+			err:         nil,
 		},
 	}
 


### PR DESCRIPTION
获取同步骨架最大大小限制错误，链分叉时，需要从分叉点开始同步，所以获取的骨架大小更大。
